### PR TITLE
yield block only if could obtain lock

### DIFF
--- a/lib/redis-lock.rb
+++ b/lib/redis-lock.rb
@@ -38,7 +38,7 @@ class Redis::Lock
       sleep @sleep.to_f
     end
 
-    yield if block_given?
+    yield if (block_given? && result == true)
 
     result
   ensure

--- a/spec/redis-lock_spec.rb
+++ b/spec/redis-lock_spec.rb
@@ -15,6 +15,20 @@ describe Redis::Lock do
     subject.try_lock.should == true
   end
 
+  it "does not yield the block if couldn't obtain the lock" do
+    flag = false
+
+    subject.lock
+
+    sleep 1.5
+
+    subject.lock do
+      flag = true
+    end
+
+    flag.should be_false
+  end
+
   it "can lock with a block" do
     subject.lock do
       subject.try_lock.should == false


### PR DESCRIPTION
The problem here is that you yield the block given in `lock.lock` whatever the result is.
If you couldn't obtain it, or it is `:recovered`, you should not allow to enter the critical section
